### PR TITLE
[FUZB-92] Allow user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ jobs:
     steps:
         - uses: git@github.com:fuzzylabs/gha-poetry-update.git@main
           with:
-            python-version: '3.10.5'
-            poetry-version: '1.5.0'
+            python-version: '3.10.12'
+            poetry-version: '1.8.2'
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ branding:
 inputs:
   python-version:
     description: "The python version to use with poetry"
-    default: '3.10.12' # Latest 3.10.x
+    default: '3.10.12'
   poetry-version:
     description: "The poetry version to use"
-    default: '1.8.2' # Latest poetry 
+    default: '1.8.2'
 
 runs:
   using: "composite"


### PR DESCRIPTION
This PR implements the functionality that allow user to input the python and the poetry version to the workflow. The readme is also update with example on how to do so.

Example of using default value:
<img width="613" alt="Screenshot 2024-03-08 at 12 48 42" src="https://github.com/fuzzylabs/gha-poetry-update/assets/25309418/cc92feef-f6d6-4486-90d0-a64f277d6761">

Example of specifying above min require value:
<img width="463" alt="Screenshot 2024-03-08 at 12 49 38" src="https://github.com/fuzzylabs/gha-poetry-update/assets/25309418/f96ededf-2932-43b0-9ca0-c9e5df8a2589">

Example where python version is below min required:
<img width="1052" alt="Screenshot 2024-03-08 at 12 45 24" src="https://github.com/fuzzylabs/gha-poetry-update/assets/25309418/8b06e17d-e712-4271-8aa4-c6ab2cc1a295">

Example where poetry version is below min required:
<img width="1047" alt="Screenshot 2024-03-08 at 12 44 04" src="https://github.com/fuzzylabs/gha-poetry-update/assets/25309418/7dd4a5ba-39b4-4f00-8af1-5de5201c641f">


## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)