### PR TITLE
[FUZB-92] Make Poetry Update Workflow Public

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,16 +86,11 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
-        VARIABLE="this"
-        echo "variable set"
-        poetry update
+        poetry update >> temp.txt
         echo "poetry updated"
-        UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')
-        echo "poetry updated and message saved"
-        echo $UPDATE_MESSAGE
         {
           echo "UPDATE_MESSAGE<<EOF"
-          echo "${UPDATE_MESSAGE}"
+          cat temp.txt
           echo "EOF"
         } >> $GITHUB_ENV
         echo "env variable assigned"

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
+        poetry update
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
         echo "poetry updated"
         echo $UPDATE_MESSAGE

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,7 @@ runs:
           cat temp.txt
           echo "EOF"
         } >> $GITHUB_ENV
+        cat temp.txt
         echo "env variable assigned"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ runs:
           cat /var/tmp/updated_deps.txt
           echo "EOF"
         } >> $GITHUB_ENV
-        rm /var/tmp/updated_dep.txt
+        rm /var/tmp/updated_deps.txt
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,6 @@ runs:
     - name: Check out repository
       if: env.RUN_UPDATE != 'false'
       uses: actions/checkout@v4
-      with:
-        ref: FUZB-91-the-branch-of-outdated-requirements
 
     - name: Set up python
       if: env.RUN_UPDATE != 'false'

--- a/action.yml
+++ b/action.yml
@@ -85,8 +85,11 @@ runs:
       run: |
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
         echo $UPDATE_MESSAGE
-
-        echo "UPDATE_MESSAGE=$UPDATE_MESSAGE" >> $GITHUB_ENV
+        {
+          echo "UPDATE_MESSAGE<<EOF"
+          echo "${UPDATE_MESSAGE}"
+          echo "EOF"
+        } >> $GITHUB_ENV
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       run: |
         poetry install --no-interaction --no-root
         echo "Running"
-        poetry update >> temp.txt
+        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> temp.txt
         echo "poetry updated"
         {
           echo "UPDATE_MESSAGE<<EOF"

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,7 @@ runs:
       run: |
         echo "Running"
         poetry update
+        echo "poetry updated"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
         echo "poetry updated"
         echo $UPDATE_MESSAGE

--- a/action.yml
+++ b/action.yml
@@ -84,10 +84,10 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         poetry install --no-interaction --no-root
-        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> temp.txt
+        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> updated_deps.txt
         {
           echo "UPDATE_MESSAGE<<EOF"
-          cat temp.txt
+          cat updated_deps.txt
           echo "EOF"
         } >> $GITHUB_ENV
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -84,14 +84,13 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         poetry install --no-interaction --no-root
-        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> /var/tmp/updated_deps.txt
+        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' > /var/tmp/updated_deps.txt
         cat /var/tmp/updated_deps.txt
         {
           echo "UPDATE_MESSAGE<<EOF"
           cat /var/tmp/updated_deps.txt
           echo "EOF"
         } >> $GITHUB_ENV
-        rm /var/tmp/updated_deps.txt
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -88,8 +88,8 @@ runs:
         echo "Running"
         poetry update
         echo "poetry updated"
-        UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
-        echo "poetry updated"
+        UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')
+        echo "poetry updated and message saved"
         echo $UPDATE_MESSAGE
         {
           echo "UPDATE_MESSAGE<<EOF"

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ runs:
     - name: Check out repository
       if: env.RUN_UPDATE != 'false'
       uses: actions/checkout@v4
+      with:
+        ref: FUZB-91-the-branch-of-outdated-requirements
 
     - name: Set up python
       if: env.RUN_UPDATE != 'false'

--- a/action.yml
+++ b/action.yml
@@ -84,13 +84,14 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         poetry install --no-interaction --no-root
-        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> updated_deps.txt
-        cat updated_deps.txt
+        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> /var/tmp/updated_deps.txt
+        cat /var/tmp/updated_deps.txt
         {
           echo "UPDATE_MESSAGE<<EOF"
-          cat updated_deps.txt
+          cat /var/tmp/updated_deps.txt
           echo "EOF"
         } >> $GITHUB_ENV
+        rm /var/tmp/updated_dep.txt
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,8 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
-        UPDATE_MESSAGE=$(poetry update)
+        poetry update
+        poetry update
         echo "poetry updated"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')
         echo "poetry updated and message saved"

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
-        poetry update
+        UPDATE_MESSAGE=$(poetry update)
         echo "poetry updated"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')
         echo "poetry updated and message saved"

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
       run: |
         poetry install --no-interaction --no-root
         poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> updated_deps.txt
+        cat updated_deps.txt
         {
           echo "UPDATE_MESSAGE<<EOF"
           cat updated_deps.txt

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,8 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
-        UPDATE_MESSAGE=${poetry update}
+        VARIABLE="this"
+        echo "variable set"
         poetry update
         echo "poetry updated"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         echo "Running"
-        poetry update
+        UPDATE_MESSAGE=${poetry update}
         poetry update
         echo "poetry updated"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies')

--- a/action.yml
+++ b/action.yml
@@ -84,16 +84,13 @@ runs:
       if: env.RUN_UPDATE != 'false'
       run: |
         poetry install --no-interaction --no-root
-        echo "Running"
         poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' >> temp.txt
-        echo "poetry updated"
         {
           echo "UPDATE_MESSAGE<<EOF"
           cat temp.txt
           echo "EOF"
         } >> $GITHUB_ENV
         cat temp.txt
-        echo "env variable assigned"
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -85,13 +85,16 @@ runs:
     - name: Run poetry update
       if: env.RUN_UPDATE != 'false'
       run: |
+        echo "Running"
         UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
+        echo "poetry updated"
         echo $UPDATE_MESSAGE
         {
           echo "UPDATE_MESSAGE<<EOF"
           echo "${UPDATE_MESSAGE}"
           echo "EOF"
         } >> $GITHUB_ENV
+        echo "env variable assigned"
       shell: bash
 
     #----------------------------------------------

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
     - name: Run poetry update
       if: env.RUN_UPDATE != 'false'
       run: |
+        poetry install --no-interaction --no-root
         echo "Running"
         poetry update >> temp.txt
         echo "poetry updated"

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,6 @@ runs:
           cat temp.txt
           echo "EOF"
         } >> $GITHUB_ENV
-        cat temp.txt
       shell: bash
 
     #----------------------------------------------


### PR DESCRIPTION
This pull request was initially designed to fix a potential issue where I believed there was potential for the action to fail to capture the update message if multiple dependencies were updated. This is done by changing the way that the update message is captured to

```        {
          echo "UPDATE_MESSAGE<<EOF"
          echo $(UPDATE_MESSAGE)
          echo "EOF"
        } >> $GITHUB_ENV
```

However, in investigating this issue, I was unable to capture the `$UPDATE_MESSAGE` variable at all. As such, rather than capturing this message in a variable in bash, it is written to a file and `echo $(UPDATE_MESSAGE)` in the above is replaced with `cat`ing that file.

Additionally, we now explicitly install poetry dependencies from the lock file before running poetry update.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)