### PR TITLE
[FUZB-92] BUGFIX on Make poetry update public

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,10 +83,14 @@ runs:
     - name: Run poetry update
       if: env.RUN_UPDATE != 'false'
       run: |
-        UPDATE_MESSAGE=$(poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g')
-        echo $UPDATE_MESSAGE
-
-        echo "UPDATE_MESSAGE=$UPDATE_MESSAGE" >> $GITHUB_ENV
+        poetry install --no-interaction --no-root
+        poetry update | grep -i 'updating' | grep -v 'Updating dependencies' | sed 's/Updating//g' > /var/tmp/updated_deps.txt
+        cat /var/tmp/updated_deps.txt
+        {
+          echo "UPDATE_MESSAGE<<EOF"
+          cat /var/tmp/updated_deps.txt
+          echo "EOF"
+        } >> $GITHUB_ENV
       shell: bash
 
     #----------------------------------------------


### PR DESCRIPTION
This pull request was initially designed to fix a potential issue where I believed there was potential for the action to fail to capture the update message if multiple dependencies were updated. This is done by changing the way that the update message is captured to

```        {
          echo "UPDATE_MESSAGE<<EOF"
          echo $(UPDATE_MESSAGE)
          echo "EOF"
        } >> $GITHUB_ENV
```

However, in investigating this issue, I was unable to capture the `$UPDATE_MESSAGE` variable at all. As such, rather than capturing this message in a variable in bash, it is written to a file and `echo $(UPDATE_MESSAGE)` in the above is replaced with `cat`ing that file.

Additionally, we now explicitly install poetry dependencies from the lock file before running poetry update.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)